### PR TITLE
grammar: too many

### DIFF
--- a/template_app_rabbitmq_service.xml
+++ b/template_app_rabbitmq_service.xml
@@ -725,7 +725,7 @@
                             <expression>{Template App Rabbitmq Service:grpavg[&quot;{#GROUPNAME}&quot;, &quot;rabbitmq.queue.messages[{#AGGVHOST},{#AGGQUEUENAME}]&quot;,last,0].min(#5)}&gt;{$MAX_MESSAGES:&quot;{#AGGVHOST}{#AGGQUEUENAME}&quot;}</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
-                            <name>Too much messages in vhost {#AGGVHOST} queue {#AGGQUEUENAME}</name>
+                            <name>Too many messages in vhost {#AGGVHOST} queue {#AGGQUEUENAME}</name>
                             <correlation_mode>0</correlation_mode>
                             <correlation_tag/>
                             <url/>


### PR DESCRIPTION
https://dictionary.cambridge.org/grammar/british-grammar/quantifiers/much-many-a-lot-of-lots-of-quantifiers#too-much-too-many-and-so-much-so-many

too-many-messages because messages are countable.